### PR TITLE
Add Sprite class, pytest tests, and CI workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,18 @@
+name: Python package
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install pillow pytest
+      - name: Run tests
+        run: pytest

--- a/sprite.py
+++ b/sprite.py
@@ -1,0 +1,28 @@
+from PIL import Image
+from typing import List
+
+class Sprite:
+    """A simple sprite supporting multiple frames for animation."""
+
+    def __init__(self, frames: List[Image.Image]):
+        if not frames:
+            raise ValueError("Sprite requires at least one frame")
+        self._frames = frames
+        self._index = 0
+
+    @property
+    def size(self):
+        """Return the (width, height) of the sprite frames."""
+        return self._frames[0].size
+
+    def render(self) -> Image.Image:
+        """Return the current frame image."""
+        return self._frames[self._index]
+
+    def next_frame(self) -> None:
+        """Advance to the next frame, looping when reaching the end."""
+        self._index = (self._index + 1) % len(self._frames)
+
+    @property
+    def frame_index(self) -> int:
+        return self._index

--- a/tests/test_sprite.py
+++ b/tests/test_sprite.py
@@ -1,0 +1,30 @@
+import pytest
+from PIL import Image
+
+from sprite import Sprite
+
+
+def make_frames(count, size=(32, 32)):
+    return [Image.new("RGBA", size, (i, i, i, 255)) for i in range(count)]
+
+
+def test_sprite_render_size():
+    frames = make_frames(2)
+    sprite = Sprite(frames)
+    img = sprite.render()
+    assert img.size == (32, 32)
+
+
+def test_animation_loops_frames():
+    frames = make_frames(3)
+    sprite = Sprite(frames)
+
+    # advance through all frames plus one to ensure loop
+    sprite.next_frame()  # -> frame 1
+    assert sprite.render() == frames[1]
+
+    sprite.next_frame()  # -> frame 2
+    assert sprite.render() == frames[2]
+
+    sprite.next_frame()  # loops back to frame 0
+    assert sprite.render() == frames[0]


### PR DESCRIPTION
## Summary
- implement simple `Sprite` class with animation support
- add unit tests verifying sprite size and looping behaviour
- configure GitHub Actions to run `pytest`

## Testing
- `pytest -q` *(fails: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684d631ae56883228c2b6f7e59b738bf