### PR TITLE
Fix test imports and animator module

### DIFF
--- a/main.py
+++ b/main.py
@@ -209,8 +209,6 @@ class SpriteAnimator:
 
 
 # Variables
-skin_var = tk.StringVar(value=to_hex(SKIN_TONES[0]))
-=======
 # Tkinter setup -----------------------------------------------------------
 root = tk.Tk()
 root.title("Sprite Face Designer")
@@ -248,16 +246,7 @@ hair_menu = tk.OptionMenu(ctrl, hair_var, *["flat", "side_part", "messy"])
 hair_menu.grid(row=1, column=1)
 # Hair color
 tk.Label(ctrl, text="Hair Color:").grid(row=2, column=0)
-hc_menu = tk.OptionMenu(
-    ctrl, hair_color_var, *[to_hex(c) for c in HAIR_COLORS]
-)
-
-hair_menu = tk.OptionMenu(ctrl, hair_var, "flat", "side_part", "messy")
-hair_menu.grid(row=1, column=1)
-# Hair color
-tk.Label(ctrl, text="Hair Color:").grid(row=2, column=0)
-hc_menu = tk.OptionMenu(ctrl, hair_color_var, *[f"#{c[0]:02X}{c[1]:02X}{c[2]:02X}" for c in HAIR_COLORS])
-
+hc_menu = tk.OptionMenu(ctrl, hair_color_var, *[to_hex(c) for c in HAIR_COLORS])
 hc_menu.grid(row=2, column=1)
 # Face color picker
 tk.Label(ctrl, text="Face Pixel Color:").grid(row=3, column=0)
@@ -292,16 +281,6 @@ for r in range(FACE_HEIGHT):
             outline="#555",
             fill="#333",
         )
-
-# Face editor grid -------------------------------------------------------
-tk.Label(ctrl, text=f"Paint Face ({FACE_WIDTH}×{FACE_HEIGHT}):").grid(row=4, column=0, columnspan=3)
-ed_cr = tk.Canvas(ctrl, width=FACE_WIDTH * EDIT_SCALE, height=FACE_HEIGHT * EDIT_SCALE, bg="#333")
-ed_cr.grid(row=5, column=0, columnspan=3)
-for r in range(FACE_HEIGHT):
-    for c in range(FACE_WIDTH):
-        ed_cr.create_rectangle(c * EDIT_SCALE, r * EDIT_SCALE,
-                               (c + 1) * EDIT_SCALE, (r + 1) * EDIT_SCALE,
-                               outline="#555", fill="#333")
 
 
 

--- a/pixelpersona/animator.py
+++ b/pixelpersona/animator.py
@@ -1,5 +1,5 @@
 import tkinter as tk
-from PIL import ImageTk
+from PIL import Image, ImageTk
 
 class SpriteAnimator:
     """Simple animator that cycles through a list of PIL images."""
@@ -7,9 +7,12 @@ class SpriteAnimator:
     def __init__(self, canvas: tk.Canvas, frames, delay=200, scale=6):
         self.canvas = canvas
         self.delay = delay
-        self.frames = [ImageTk.PhotoImage(img.resize((img.width*scale, img.height*scale),
-                                                    Image.NEAREST))
-                       for img in frames]
+        self.frames = [
+            ImageTk.PhotoImage(
+                img.resize((img.width * scale, img.height * scale), Image.NEAREST)
+            )
+            for img in frames
+        ]
         self.index = 0
         self.running = False
 

--- a/tests/test_sprite.py
+++ b/tests/test_sprite.py
@@ -1,6 +1,8 @@
-import pytest
+import os
+import sys
 from PIL import Image
 
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from sprite import Sprite
 
 


### PR DESCRIPTION
## Summary
- import `Image` in `SpriteAnimator` and reformat frame resize
- ensure tests run by updating `sys.path`
- trim leftover merge markers and duplicated UI setup in `main.py`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d67cc6ddc83229ddd0d5ca62cb4cd